### PR TITLE
add sdf-to-KDL conversion

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -10,5 +10,6 @@
   <depend package="control/kdl" />
   <depend package="base/types"/>
   <depend package="control/urdfdom"/>
+  <depend package="control/sdformat"/>
 
 </package>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
-rock_find_cmake(Boost)
+rock_find_cmake(Boost REQUIRED COMPONENTS thread system)
 
-rock_library(kdl_parser SOURCES kdl_parser.cpp
+rock_library(kdl_parser SOURCES kdl_parser.cpp sdf.cpp
                         HEADERS kdl_parser.hpp
                         DEPS_PKGCONFIG 
 			  eigen3 
@@ -9,4 +9,5 @@ rock_library(kdl_parser SOURCES kdl_parser.cpp
 			  tinyxml
                           urdfdom_headers 
 			  urdfdom
+                          sdformat
 )

--- a/src/kdl_parser.cpp
+++ b/src/kdl_parser.cpp
@@ -46,6 +46,15 @@ using namespace KDL;
 
 namespace kdl_parser{
 
+/**
+ * load kdl tree from sdf xml string
+ */
+extern bool treeFromSdfString(const std::string& xml, KDL::Tree& tree);
+
+/**
+ * load kdl tree from sdf file
+ */
+extern bool treeFromSdfFile(const std::string& path, KDL::Tree& tree);
 
 // construct vector
 Vector toKdl(urdf::Vector3 v)
@@ -130,11 +139,23 @@ bool addChildrenToTree(urdf::LinkConstSharedPtr root, Tree& tree)
 }
 
 
-bool treeFromFile(const string& path, Tree& tree)
+bool treeFromFile(const string& path, Tree& tree, ROBOT_MODEL_FORMAT format)
 {
-    std::ifstream file(path.c_str());
-    std::string str((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
-    return treeFromString(str, tree);
+    switch (format)
+    {
+        case ROBOT_MODEL_URDF:
+        {
+            std::ifstream file(path.c_str());
+            std::string str((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+            return treeFromString(str, tree);
+        }
+        case ROBOT_MODEL_SDF:
+        {
+            return treeFromSdfFile(path, tree);
+        }
+    }
+
+    return false;
 }
 
 #if 0
@@ -149,10 +170,22 @@ bool treeFromParam(const string& param, Tree& tree)
 }
 #endif
 
-bool treeFromString(const string& xml, Tree& tree)
+bool treeFromString(const string& xml, Tree& tree, ROBOT_MODEL_FORMAT format)
 {
-    urdf::ModelInterfaceSharedPtr robot_model = urdf::parseURDF(xml);
-    return treeFromUrdfModel(*robot_model, tree);
+    switch (format)
+    {
+        case ROBOT_MODEL_URDF:
+        {
+            urdf::ModelInterfaceSharedPtr robot_model = urdf::parseURDF(xml);
+            return treeFromUrdfModel(*robot_model, tree);
+        }
+        case ROBOT_MODEL_SDF:
+        {
+            return treeFromSdfString(xml, tree);
+        }
+    }
+
+    return false;
 }
 
 bool treeFromUrdfModel(const urdf::ModelInterface& robot_model, Tree& tree)

--- a/src/kdl_parser.cpp
+++ b/src/kdl_parser.cpp
@@ -46,6 +46,29 @@ using namespace KDL;
 
 namespace kdl_parser{
 
+const char* formatNameFromID(int type)
+{
+    switch(type)
+    {
+        case ROBOT_MODEL_AUTO: return "autodetected";
+        case ROBOT_MODEL_URDF: return "URDF";
+        case ROBOT_MODEL_SDF: return "SDF";
+        default:
+            throw std::invalid_argument("invalid model type ID given");
+    }
+}
+
+ROBOT_MODEL_FORMAT guessFormatFromFilename(const std::string& file)
+{
+    if (file.substr(file.size() - 4) == ".sdf")
+        return ROBOT_MODEL_SDF;
+    if (file.substr(file.size() - 5) == ".urdf")
+        return ROBOT_MODEL_URDF;
+    if (file.substr(file.size() - 6) == ".world")
+        return ROBOT_MODEL_SDF;
+    throw std::invalid_argument("cannot guess robot model format for " + file);
+}
+
 /**
  * load kdl tree from sdf xml string
  */
@@ -141,6 +164,9 @@ bool addChildrenToTree(urdf::LinkConstSharedPtr root, Tree& tree)
 
 bool treeFromFile(const string& path, Tree& tree, ROBOT_MODEL_FORMAT format)
 {
+    if (format == ROBOT_MODEL_AUTO)
+        format = guessFormatFromFilename(path);
+
     switch (format)
     {
         case ROBOT_MODEL_URDF:
@@ -153,6 +179,8 @@ bool treeFromFile(const string& path, Tree& tree, ROBOT_MODEL_FORMAT format)
         {
             return treeFromSdfFile(path, tree);
         }
+        default:
+            throw invalid_argument(std::string("cannot load file of type ") + formatNameFromID(format));
     }
 
     return false;
@@ -183,6 +211,8 @@ bool treeFromString(const string& xml, Tree& tree, ROBOT_MODEL_FORMAT format)
         {
             return treeFromSdfString(xml, tree);
         }
+        default:
+            throw invalid_argument(std::string("cannot load string of type ") + formatNameFromID(format));
     }
 
     return false;

--- a/src/kdl_parser.hpp
+++ b/src/kdl_parser.hpp
@@ -39,17 +39,26 @@
 
 #include <kdl/tree.hpp>
 #include <string>
-#include "urdf_model/model.h"
 #include <tinyxml.h>
+#include <sdf/sdf.hh>
+#include "urdf_model/model.h"
 
 namespace kdl_parser{
+
+//define format of robot model
+enum ROBOT_MODEL_FORMAT
+{
+   ROBOT_MODEL_URDF,
+   ROBOT_MODEL_SDF
+};
+
 
 /** Constructs a KDL tree from a file, given the file name
  * \param file The filename from where to read the xml
  * \param tree The resulting KDL Tree
  * returns true on success, false on failure
  */
-bool treeFromFile(const std::string& file, KDL::Tree& tree);
+bool treeFromFile(const std::string& file, KDL::Tree& tree, ROBOT_MODEL_FORMAT format = ROBOT_MODEL_URDF);
 
 #if 0
 /** Constructs a KDL tree from the parameter server, given the parameter name
@@ -65,7 +74,7 @@ bool treeFromParam(const std::string& param, KDL::Tree& tree);
  * \param tree The resulting KDL Tree
  * returns true on success, false on failure
  */
-bool treeFromString(const std::string& xml, KDL::Tree& tree);
+bool treeFromString(const std::string& xml, KDL::Tree& tree, ROBOT_MODEL_FORMAT format = ROBOT_MODEL_URDF);
 
 /** Constructs a KDL tree from a URDF robot model
  * \param robot_model The URDF robot model
@@ -73,6 +82,12 @@ bool treeFromString(const std::string& xml, KDL::Tree& tree);
  * returns true on success, false on failure
  */
 bool treeFromUrdfModel(const urdf::ModelInterface& robot_model, KDL::Tree& tree);
+
+/** Constructs a KDL tree from a SDF robot model
+ * \param robot_model The SDF robot model
+ * \param tree The resulting KDL Tree
+ */
+void treeFromSdfModel(const sdf::ElementPtr& sdf_model, KDL::Tree& out);
 }
 
 #endif

--- a/src/kdl_parser.hpp
+++ b/src/kdl_parser.hpp
@@ -48,10 +48,21 @@ namespace kdl_parser{
 //define format of robot model
 enum ROBOT_MODEL_FORMAT
 {
-   ROBOT_MODEL_URDF,
-   ROBOT_MODEL_SDF
+    //! try to guess the format
+    ROBOT_MODEL_AUTO,
+    //! URDF model
+    ROBOT_MODEL_URDF,
+    //! SDF model
+    ROBOT_MODEL_SDF
 };
 
+/** Returns the model format based on a filename's extension
+ */
+ROBOT_MODEL_FORMAT guessFormatFromFilename(const std::string& file);
+
+/** Returns the name of one of the ROBOT_MODEL_* format IDs
+ */
+const char* formatNameFromID(int type);
 
 /** Constructs a KDL tree from a file, given the file name
  * \param file The filename from where to read the xml

--- a/src/sdf.cpp
+++ b/src/sdf.cpp
@@ -1,4 +1,4 @@
-#include <base/Logging.hpp>
+#include <base-logging/Logging.hpp>
 #include <kdl/tree.hpp>
 #include "kdl_parser.hpp"
 #include <sdf/sdf.hh>

--- a/src/sdf.cpp
+++ b/src/sdf.cpp
@@ -69,18 +69,22 @@ KDL::Joint sdfJointToKdl(sdf::ElementPtr sdf)
     std::string name = sdf->Get<std::string>("name");
     std::string type = sdf->Get<std::string>("type");
 
-    if (sdf->HasElement("pose")){
-         KDL::Frame pose = toKdl(sdf->GetElement("pose")->Get<sdf::Pose>());
-         if (type == "revolute"){
-             KDL::Vector axis = toKdl(sdf->GetElement("axis")->GetElement("xyz")->Get<sdf::Vector3>());
-             return KDL::Joint(name, pose.p, pose.M * axis, KDL::Joint::RotAxis);
-         }
-         else if (type == "prismatic"){
-             KDL::Vector axis = toKdl(sdf->GetElement("axis")->GetElement("xyz")->Get<sdf::Vector3>());
-             return KDL::Joint(name, pose.p, pose.M * axis, KDL::Joint::TransAxis);
-         }
 
+    //if the joint there isn't a pose, this pose will be the origin to the parent link
+    KDL::Frame pose;
+    if (sdf->HasElement("pose")){
+         pose = toKdl(sdf->GetElement("pose")->Get<sdf::Pose>());
     }
+
+    if (type == "revolute"){
+        KDL::Vector axis = toKdl(sdf->GetElement("axis")->GetElement("xyz")->Get<sdf::Vector3>());
+        return KDL::Joint(name, pose.p, pose.M * axis, KDL::Joint::RotAxis);
+    }
+    else if (type == "prismatic"){
+        KDL::Vector axis = toKdl(sdf->GetElement("axis")->GetElement("xyz")->Get<sdf::Vector3>());
+        return KDL::Joint(name, pose.p, pose.M * axis, KDL::Joint::TransAxis);
+    }
+
 
     return KDL::Joint(KDL::Joint::None);
 }

--- a/src/sdf.cpp
+++ b/src/sdf.cpp
@@ -1,0 +1,277 @@
+#include <base/Logging.hpp>
+#include <kdl/tree.hpp>
+#include <sdf/sdf.hh>
+
+
+namespace kdl_parser {
+/*
+ * SDF to KDL
+ * bellow there are the source codes to convert SDFs information to KDL
+ */
+typedef std::map<std::string, sdf::ElementPtr> JointsMap;
+typedef std::map<std::string, sdf::ElementPtr> LinksMap;
+typedef std::map<std::string, std::vector<std::string> > LinkNamesMap;
+
+
+/**
+ * convert <axis> element to KDL::Vector
+ */
+KDL::Vector toKdl(sdf::Vector3 axis)
+{
+    return KDL::Vector(axis.x, axis.y, axis.z);
+}
+
+/**
+ * convert <pose> element to KDL::Frame
+ */
+KDL::Frame toKdl(sdf::Pose pose)
+{
+    KDL::Rotation rotation = KDL::Rotation::Quaternion(pose.rot.x, pose.rot.y, pose.rot.x, pose.rot.w);
+    KDL::Vector position = KDL::Vector(pose.pos.x, pose.pos.y, pose.pos.z);
+    return KDL::Frame(rotation, position);
+}
+
+/**
+ * convert <inertial> element to KDL::RigidBodyInertia
+ */
+KDL::RigidBodyInertia sdfInertiaToKdl(sdf::ElementPtr sdf)
+{
+    KDL::Frame pose = toKdl(sdf->GetElement("pose")->Get<sdf::Pose>());
+    double mass;
+
+    if (sdf->HasElement("mass")){
+        mass = sdf->GetElement("mass")->Get<double>();
+        if (sdf->HasElement("inertia")){
+
+            sdf::ElementPtr sdf_inertia = sdf->GetElement("inertia");
+
+            const char *tags[] = {"ixx", "ixy", "ixz", "iyy", "iyz", "izz" };
+
+            double ixx, ixy, ixz, iyy, iyz, izz;
+            double *ptr[] = {&ixx, &ixy, &ixz, &iyy, &iyz, &izz};
+
+            for (int i = 0; i < 6; i++){
+                (*ptr[i]) = sdf_inertia->GetElement(tags[i])->Get<double>();
+            }
+
+            return pose.M * KDL::RigidBodyInertia(mass, pose.p, KDL::RotationalInertia(ixx, iyy, izz, ixy, ixz, iyz));
+        }
+    }
+
+    return KDL::RigidBodyInertia();
+}
+
+/**
+ * convert <joint> element to KDL::Joint
+ */
+KDL::Joint sdfJointToKdl(sdf::ElementPtr sdf)
+{
+    std::string name = sdf->Get<std::string>("name");
+    std::string type = sdf->Get<std::string>("type");
+
+    if (sdf->HasElement("pose")){
+         KDL::Frame pose = toKdl(sdf->GetElement("pose")->Get<sdf::Pose>());
+         if (type == "revolute"){
+             KDL::Vector axis = toKdl(sdf->GetElement("axis")->Get<sdf::Vector3>());
+             return KDL::Joint(name, pose.p, pose.M * axis, KDL::Joint::RotAxis);
+         }
+         else if (type == "prismatic"){
+             KDL::Vector axis = toKdl(sdf->GetElement("axis")->Get<sdf::Vector3>());
+             return KDL::Joint(name, pose.p, pose.M * axis, KDL::Joint::TransAxis);
+         }
+
+    }
+
+    return KDL::Joint(KDL::Joint::None);
+}
+
+
+/**
+ * Fill KDL::Tree with SDF information
+ */
+void fillKdlTreeFromSDF(LinkNamesMap linkNames,
+                        JointsMap joints,
+                        LinksMap links,
+                        std::string parent_name,
+                        KDL::Tree& tree)
+{
+
+    LinkNamesMap::iterator parentItr = linkNames.find(parent_name);
+
+    if (parentItr != linkNames.end()){
+        for (std::vector<std::string>::iterator childItr = parentItr->second.begin();
+             childItr != parentItr->second.end(); childItr++) {
+
+            KDL::Joint joint;
+            KDL::RigidBodyInertia I;
+
+            LinksMap::iterator link_itr = links.find(*childItr);
+
+            if (link_itr != links.end()){
+                sdf::ElementPtr sdf_link = link_itr->second;
+
+                if (sdf_link->HasElement("inertial")){
+                    I = sdfInertiaToKdl(sdf_link->GetElement("inertial"));
+                }
+            }
+
+            JointsMap::iterator  joint_itr = joints.find(*childItr);
+
+            if (joint_itr != joints.end()){
+                sdf::ElementPtr sdf_joint = joint_itr->second;
+                joint = sdfJointToKdl(sdf_joint);
+            }
+
+
+            KDL::Segment segment(*childItr, joint,
+                                            KDL::Frame(),
+                                            I);
+
+            tree.addSegment(segment, parent_name);
+
+            fillKdlTreeFromSDF(linkNames, joints, links, *childItr, tree);
+        }
+    }
+}
+
+/**
+ * create a data structure to map <joint> elements
+ * use link child as key to map refence the joints
+ * if joint is a child then it has a joint
+ */
+JointsMap sdfLoadJoints(sdf::ElementPtr sdf_model)
+{
+    JointsMap joints;
+
+    if (sdf_model->HasElement("joint")) {
+        sdf::ElementPtr jointElem = sdf_model->GetElement("joint");
+
+        while (jointElem) {
+            std::string childLinkName = jointElem->GetElement("child")->Get<std::string>();
+            joints.insert(std::make_pair<std::string, sdf::ElementPtr>(childLinkName, jointElem));
+            jointElem = jointElem->GetNextElement("joint");
+        }
+    }
+
+    return joints;
+}
+
+/**
+ * create a data structure to map <link> elements
+ * use link name as key to map the links
+ */
+LinksMap sdfLoadLinks(sdf::ElementPtr sdf_model)
+{
+    std::map<std::string, sdf::ElementPtr> links;
+
+    if (sdf_model->HasElement("link")) {
+        sdf::ElementPtr linkElem = sdf_model->GetElement("link");
+        while (linkElem) {
+            std::string linkName = linkElem->Get<std::string>("name");
+            links.insert(std::make_pair<std::string, sdf::ElementPtr>(linkName, linkElem));
+            linkElem = linkElem->GetNextElement("link");
+        }
+    }
+
+    return links;
+}
+
+/**
+ * create a structure to map parent and child
+ * each parent has a list of children
+ * this result is used to fill KDL::Tree
+ */
+LinkNamesMap sdfBuildLinkNames(LinksMap links, JointsMap joints, std::string rootName)
+{
+
+    LinkNamesMap linkNames;
+    LinksMap::iterator linksItr;
+    JointsMap::iterator jointItr;
+
+    //list each link and build and associate each child to its parent
+    for (linksItr = links.begin(); linksItr != links.end(); linksItr++){
+        std::string child_name = linksItr->first;
+        std::string parent_name = rootName;
+
+        //check if child has a parent
+        if ((jointItr = joints.find(child_name)) != joints.end()) {
+            parent_name = jointItr->second->GetElement("parent")->Get<std::string>();
+        }
+
+        //insert child name in vector associated with parent name
+        LinkNamesMap::iterator itr = linkNames.find(parent_name);
+        if (itr == linkNames.end()){
+            std::vector<std::string> childs;
+            childs.push_back(child_name);
+            linkNames.insert(std::make_pair<std::string, std::vector<std::string> >(parent_name, childs));
+        }
+        else {
+            itr->second.push_back(child_name);
+        }
+    }
+
+    return linkNames;
+
+}
+
+void treeFromSdfModel(const sdf::ElementPtr& sdf_model, KDL::Tree& out)
+{
+    // model is the root segment
+    std::string modelName = sdf_model->Get<std::string>("name");
+
+    // map parents and children links
+    LinksMap links = sdfLoadLinks(sdf_model);
+
+    // map links using link name
+    JointsMap joints = sdfLoadJoints(sdf_model);
+
+    // map joints using child link names
+    LinkNamesMap linkNames = sdfBuildLinkNames(links, joints, modelName);
+
+    //build KDL::Tree using SDF information
+    KDL::Tree tree(modelName);
+    fillKdlTreeFromSDF(linkNames, joints, links, tree.getRootSegment()->first, tree);
+    out = tree;
+}
+
+/**
+ * load kdl tree from sdf xml string
+ */
+bool treeFromSdfString(const std::string& xml, KDL::Tree& tree)
+{
+    sdf::SDFPtr sdf(new sdf::SDF);
+
+    if (!sdf::init(sdf)){
+        LOG_ERROR("unable to initialize sdf.");
+        return false;
+    }
+
+    if (!sdf::readString(xml, sdf)){
+        LOG_ERROR("unable to read xml string.");
+        return false;
+    }
+
+    if (!sdf->root->HasElement("model")){
+        LOG_ERROR("the <model> tag not exists");
+        return false;
+    }
+
+    treeFromSdfModel(sdf->root->GetElement("model"), tree);
+
+    return true;
+}
+
+/**
+ * load kdl tree from sdf file
+ */
+bool treeFromSdfFile(const std::string& path, KDL::Tree& tree)
+{
+    std::ifstream file(path.c_str());
+    std::string str((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    return treeFromSdfString(str, tree);
+}
+
+}
+
+
+

--- a/src/sdf.cpp
+++ b/src/sdf.cpp
@@ -118,6 +118,7 @@ void fillKdlTreeFromSDF(LinkNamesMap linkNames,
                         JointsMap joints,
                         LinksMap links,
                         std::string parent_name,
+                        std::string model_name,
                         KDL::Tree& tree)
 {
 
@@ -177,7 +178,7 @@ void fillKdlTreeFromSDF(LinkNamesMap linkNames,
                 joint_axis = joint2model.M.Inverse() * joint_axis;
             }
 
-            KDL::Joint joint = toKdl(joint_name, joint_type, joint2parent, joint_axis);
+            KDL::Joint joint = toKdl(model_name + "::" + joint_name, joint_type, joint2parent, joint_axis);
 
 
             KDL::Segment segment(*childItr, joint,
@@ -186,7 +187,7 @@ void fillKdlTreeFromSDF(LinkNamesMap linkNames,
 
             tree.addSegment(segment, parent_name);
 
-            fillKdlTreeFromSDF(linkNames, joints, links, *childItr, tree);
+            fillKdlTreeFromSDF(linkNames, joints, links, *childItr, model_name, tree);
         }
     }
     else{
@@ -285,7 +286,7 @@ void treeFromSdfModel(const sdf::ElementPtr& sdf_model, KDL::Tree& out)
 
     //build KDL::Tree using SDF information
     KDL::Tree tree(modelName);
-    fillKdlTreeFromSDF(linkNames, joints, links, tree.getRootSegment()->first, tree);
+    fillKdlTreeFromSDF(linkNames, joints, links, tree.getRootSegment()->first, modelName, tree);
     out = tree;
 }
 

--- a/src/sdf.cpp
+++ b/src/sdf.cpp
@@ -131,8 +131,7 @@ void fillKdlTreeFromSDF(LinkNamesMap linkNames,
             LinksMap::iterator child_link_itr = links.find(*childItr);
 
             if (child_link_itr == links.end()){
-                std::cerr << "internal error: cannot find link: " << *childItr << std::endl;
-                return;
+                throw std::logic_error("cannot find link " + *childItr);
             }
 
             sdf::ElementPtr sdf_child_link = child_link_itr->second;
@@ -189,6 +188,9 @@ void fillKdlTreeFromSDF(LinkNamesMap linkNames,
 
             fillKdlTreeFromSDF(linkNames, joints, links, *childItr, tree);
         }
+    }
+    else{
+        throw std::logic_error("could not find link " + parent_name);
     }
 }
 
@@ -258,6 +260,9 @@ LinkNamesMap sdfBuildLinkNames(LinksMap links, JointsMap joints, std::string roo
 
         //insert child name in vector associated with parent name
         linkNames[parent_name].push_back(child_name);
+        //make sure to register the child, even with an empty vector. There is a
+        //consistency check in treeFromSdfString that requires it.
+        linkNames[child_name];
     }
 
     return linkNames;

--- a/src/sdf.cpp
+++ b/src/sdf.cpp
@@ -50,8 +50,9 @@ static KDL::Joint toKdl(string name, string type, KDL::Frame pose, KDL::Vector a
     else if (type == "prismatic"){
         return KDL::Joint(name, pose.p, pose.M * axis, KDL::Joint::TransAxis);
     }
+    else
+        throw runtime_error("cannot handle joint type " + type);
 
-    return KDL::Joint(KDL::Joint::None);
 }
 
 /**

--- a/src/sdf.cpp
+++ b/src/sdf.cpp
@@ -304,6 +304,12 @@ void kdl_parser::treeFromSdfModel(const sdf::ElementPtr& sdf_model, KDL::Tree& o
     //build KDL::Tree using SDF information
     KDL::Tree tree(model_name);
 
+    if (!sdf_model->HasElement("link"))
+    {
+        out = tree;
+        return;
+    }
+
     bool static_model = sdfIsModelStatic(sdf_model);
     sdf::ElementPtr sdf_root_link = sdf_model->GetElement("link");
     if (static_model) {

--- a/src/sdf.cpp
+++ b/src/sdf.cpp
@@ -50,6 +50,9 @@ static KDL::Joint toKdl(string name, string type, KDL::Frame pose, KDL::Vector a
     else if (type == "prismatic"){
         return KDL::Joint(name, pose.p, pose.M * axis, KDL::Joint::TransAxis);
     }
+    else if (type == "fixed"){
+        return KDL::Joint(name, KDL::Joint::None);
+    }
     else
         throw runtime_error("cannot handle joint type " + type);
 

--- a/src/sdf.cpp
+++ b/src/sdf.cpp
@@ -1,10 +1,10 @@
 #include <base/Logging.hpp>
 #include <kdl/tree.hpp>
+#include "kdl_parser.hpp"
 #include <sdf/sdf.hh>
 
 using namespace std;
 
-namespace kdl_parser {
 /*
  * SDF to KDL
  * bellow there are the source codes to convert SDFs information to KDL
@@ -17,7 +17,7 @@ typedef map<string, vector<string> > LinkNamesMap;
 /**
  * convert <axis> element to KDL::Vector
  */
-KDL::Vector toKdl(sdf::Vector3 axis)
+static KDL::Vector toKdl(sdf::Vector3 axis)
 {
     return KDL::Vector(axis.x, axis.y, axis.z);
 }
@@ -25,7 +25,7 @@ KDL::Vector toKdl(sdf::Vector3 axis)
 /**
  * convert <pose> element to KDL::Frame
  */
-KDL::Frame toKdl(sdf::Pose pose)
+static KDL::Frame toKdl(sdf::Pose pose)
 {
     KDL::Vector position = KDL::Vector(pose.pos.x, pose.pos.y, pose.pos.z);
     KDL::Rotation rotation = KDL::Rotation::Quaternion(pose.rot.x, pose.rot.y, pose.rot.z, pose.rot.w);
@@ -35,7 +35,7 @@ KDL::Frame toKdl(sdf::Pose pose)
 /**
  * convert <joint> element to KDL::Joint
  */
-KDL::Joint toKdl(string name, string type, KDL::Frame pose, KDL::Vector axis)
+static KDL::Joint toKdl(string name, string type, KDL::Frame pose, KDL::Vector axis)
 {
     if (type == "revolute"){
         return KDL::Joint(name, pose.p, pose.M * axis, KDL::Joint::RotAxis);
@@ -50,7 +50,7 @@ KDL::Joint toKdl(string name, string type, KDL::Frame pose, KDL::Vector axis)
 /**
  * convert <inertial> element to KDL::RigidBodyInertia
  */
-KDL::RigidBodyInertia sdfInertiaToKdl(sdf::ElementPtr sdf)
+static KDL::RigidBodyInertia sdfInertiaToKdl(sdf::ElementPtr sdf)
 {
     KDL::Frame pose = toKdl(sdf->GetElement("pose")->Get<sdf::Pose>());
     double mass;
@@ -81,7 +81,7 @@ KDL::RigidBodyInertia sdfInertiaToKdl(sdf::ElementPtr sdf)
 /*
  * extract joint data
  */
-void sdfExtractJointData(sdf::ElementPtr sdf_joint,
+static void sdfExtractJointData(sdf::ElementPtr sdf_joint,
                          string& joint_name,
                          string& joint_type,
                          KDL::Frame& joint_pose,
@@ -115,7 +115,7 @@ void sdfExtractJointData(sdf::ElementPtr sdf_joint,
 /**
  * Fill KDL::Tree with SDF information
  */
-void fillKdlTreeFromSDF(LinkNamesMap linkNames,
+static void fillKdlTreeFromSDF(LinkNamesMap linkNames,
                         JointsMap joints,
                         LinksMap links,
                         string parent_name,
@@ -201,7 +201,7 @@ void fillKdlTreeFromSDF(LinkNamesMap linkNames,
  * use link child as key to map refence the joints
  * if joint is a child then it has a joint
  */
-JointsMap sdfLoadJoints(string name_prefix, sdf::ElementPtr sdf_model)
+static JointsMap sdfLoadJoints(string name_prefix, sdf::ElementPtr sdf_model)
 {
     JointsMap joints;
 
@@ -222,7 +222,7 @@ JointsMap sdfLoadJoints(string name_prefix, sdf::ElementPtr sdf_model)
  * create a data structure to map <link> elements
  * use link name as key to map the links
  */
-LinksMap sdfLoadLinks(string name_prefix, sdf::ElementPtr sdf_model)
+static LinksMap sdfLoadLinks(string name_prefix, sdf::ElementPtr sdf_model)
 {
     map<string, sdf::ElementPtr> links;
 
@@ -243,7 +243,7 @@ LinksMap sdfLoadLinks(string name_prefix, sdf::ElementPtr sdf_model)
  * each parent has a list of children
  * this result is used to fill KDL::Tree
  */
-LinkNamesMap sdfBuildLinkNames(LinksMap links, JointsMap joints, string rootName)
+static LinkNamesMap sdfBuildLinkNames(LinksMap links, JointsMap joints, string rootName)
 {
 
     LinkNamesMap linkNames;
@@ -271,7 +271,7 @@ LinkNamesMap sdfBuildLinkNames(LinksMap links, JointsMap joints, string rootName
 
 }
 
-void treeFromSdfModel(const sdf::ElementPtr& sdf_model, KDL::Tree& out)
+void kdl_parser::treeFromSdfModel(const sdf::ElementPtr& sdf_model, KDL::Tree& out)
 {
     // model is the root segment
     string modelName = sdf_model->Get<string>("name");
@@ -291,6 +291,7 @@ void treeFromSdfModel(const sdf::ElementPtr& sdf_model, KDL::Tree& out)
     out = tree;
 }
 
+namespace kdl_parser {
 /**
  * load kdl tree from sdf xml string
  */
@@ -329,6 +330,3 @@ bool treeFromSdfFile(const string& path, KDL::Tree& tree)
 }
 
 }
-
-
-

--- a/src/sdf.cpp
+++ b/src/sdf.cpp
@@ -26,8 +26,8 @@ KDL::Vector toKdl(sdf::Vector3 axis)
  */
 KDL::Frame toKdl(sdf::Pose pose)
 {
-    KDL::Rotation rotation = KDL::Rotation::Quaternion(pose.rot.x, pose.rot.y, pose.rot.x, pose.rot.w);
     KDL::Vector position = KDL::Vector(pose.pos.x, pose.pos.y, pose.pos.z);
+    KDL::Rotation rotation = KDL::Rotation::Quaternion(pose.rot.x, pose.rot.y, pose.rot.z, pose.rot.w);
     return KDL::Frame(rotation, position);
 }
 
@@ -72,11 +72,11 @@ KDL::Joint sdfJointToKdl(sdf::ElementPtr sdf)
     if (sdf->HasElement("pose")){
          KDL::Frame pose = toKdl(sdf->GetElement("pose")->Get<sdf::Pose>());
          if (type == "revolute"){
-             KDL::Vector axis = toKdl(sdf->GetElement("axis")->Get<sdf::Vector3>());
+             KDL::Vector axis = toKdl(sdf->GetElement("axis")->GetElement("xyz")->Get<sdf::Vector3>());
              return KDL::Joint(name, pose.p, pose.M * axis, KDL::Joint::RotAxis);
          }
          else if (type == "prismatic"){
-             KDL::Vector axis = toKdl(sdf->GetElement("axis")->Get<sdf::Vector3>());
+             KDL::Vector axis = toKdl(sdf->GetElement("axis")->GetElement("xyz")->Get<sdf::Vector3>());
              return KDL::Joint(name, pose.p, pose.M * axis, KDL::Joint::TransAxis);
          }
 
@@ -126,6 +126,10 @@ void fillKdlTreeFromSDF(LinkNamesMap linkNames,
             KDL::Segment segment(*childItr, joint,
                                             KDL::Frame(),
                                             I);
+
+//            KDL::Segment segment(*childItr, KDL::Joint(),
+//                                            KDL::Frame(),
+//                                            KDL::RigidBodyInertia());
 
             tree.addSegment(segment, parent_name);
 

--- a/src/sdf.cpp
+++ b/src/sdf.cpp
@@ -32,6 +32,21 @@ KDL::Frame toKdl(sdf::Pose pose)
 }
 
 /**
+ * convert <joint> element to KDL::Joint
+ */
+KDL::Joint toKdl(std::string name, std::string type, KDL::Frame pose, KDL::Vector axis)
+{
+    if (type == "revolute"){
+        return KDL::Joint(name, pose.p, pose.M * axis, KDL::Joint::RotAxis);
+    }
+    else if (type == "prismatic"){
+        return KDL::Joint(name, pose.p, pose.M * axis, KDL::Joint::TransAxis);
+    }
+
+    return KDL::Joint(KDL::Joint::None);
+}
+
+/**
  * convert <inertial> element to KDL::RigidBodyInertia
  */
 KDL::RigidBodyInertia sdfInertiaToKdl(sdf::ElementPtr sdf)
@@ -59,21 +74,6 @@ KDL::RigidBodyInertia sdfInertiaToKdl(sdf::ElementPtr sdf)
     }
 
     return KDL::RigidBodyInertia();
-}
-
-/**
- * convert <joint> element to KDL::Joint
- */
-KDL::Joint sdfJointToKdl(std::string name, std::string type, KDL::Frame pose, KDL::Vector axis)
-{
-    if (type == "revolute"){
-        return KDL::Joint(name, pose.p, pose.M * axis, KDL::Joint::RotAxis);
-    }
-    else if (type == "prismatic"){
-        return KDL::Joint(name, pose.p, pose.M * axis, KDL::Joint::TransAxis);
-    }
-
-    return KDL::Joint(KDL::Joint::None);
 }
 
 
@@ -178,7 +178,7 @@ void fillKdlTreeFromSDF(LinkNamesMap linkNames,
                 joint_axis = joint2model.M.Inverse() * joint_axis;
             }
 
-            KDL::Joint joint = sdfJointToKdl(joint_name, joint_type, joint2parent, joint_axis);
+            KDL::Joint joint = toKdl(joint_name, joint_type, joint2parent, joint_axis);
 
 
             KDL::Segment segment(*childItr, joint,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+rock_testsuite(test_suite suite.cpp
+   test_sdf.cpp
+   DEPS kdl_parser)

--- a/test/suite.cpp
+++ b/test/suite.cpp
@@ -1,0 +1,5 @@
+// Do NOT add anything to this file
+// This header from boost takes ages to compile, so we make sure it is compiled
+// only once (here)
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>

--- a/test/test_sdf.cpp
+++ b/test/test_sdf.cpp
@@ -1,0 +1,108 @@
+#include <boost/test/unit_test.hpp>
+#include <kdl_parser/kdl_parser.hpp>
+
+using namespace kdl_parser;
+using namespace std;
+using namespace KDL;
+
+BOOST_AUTO_TEST_CASE(it_sets_the_root_segment_to_the_model_name_and_rigidly_links_the_root_link_to_it)
+{
+    string sdf = "<sdf version=\"1.6\"><model name=\"test\"><link name=\"root\" /></model></sdf>";
+    Tree tree;
+    BOOST_REQUIRE(treeFromString(sdf, tree, kdl_parser::ROBOT_MODEL_SDF));
+
+    TreeElement const& treeRoot = tree.getRootSegment()->second;
+    BOOST_REQUIRE_EQUAL("test", treeRoot.segment.getName());
+    TreeElement const& rootLink = treeRoot.children[0]->second;
+    BOOST_REQUIRE_EQUAL("test::root", rootLink.segment.getName());
+}
+
+BOOST_AUTO_TEST_CASE(it_discovers_the_children_of_the_root_link_and_links_them_to_it)
+{
+    string sdf = "\
+        <sdf version=\"1.6\">\
+        <model name=\"test\">\
+            <link name=\"root\" />\
+            <link name=\"child0\" />\
+            <link name=\"child0_child\" />\
+            <link name=\"child1\" />\
+            \
+            <joint name=\"j0\" type=\"fixed\">\
+                <parent>root</parent>\
+                <child>child0</child>\
+            </joint>\
+            <joint name=\"j1\" type=\"fixed\">\
+                <parent>root</parent>\
+                <child>child1</child>\
+            </joint>\
+            <joint name=\"j2\" type=\"fixed\">\
+                <parent>child0</parent>\
+                <child>child0_child</child>\
+            </joint>\
+        </model>\
+        </sdf>";
+    Tree tree;
+    BOOST_REQUIRE(treeFromString(sdf, tree, kdl_parser::ROBOT_MODEL_SDF));
+    TreeElement const& rootLink = tree.getRootSegment()->second.children[0]->second;
+    BOOST_REQUIRE_EQUAL("test::root", rootLink.segment.getName());
+    BOOST_REQUIRE_EQUAL(2, rootLink.children.size());
+
+    TreeElement const& child0 = rootLink.children[0]->second;
+    BOOST_REQUIRE_EQUAL("test::child0", child0.segment.getName());
+    BOOST_REQUIRE_EQUAL("test::j0", child0.segment.getJoint().getName());
+    TreeElement const& child1 = rootLink.children[1]->second;
+    BOOST_REQUIRE_EQUAL("test::child1", child1.segment.getName());
+    BOOST_REQUIRE_EQUAL("test::j1", child1.segment.getJoint().getName());
+
+    BOOST_REQUIRE_EQUAL(1, child0.children.size());
+    TreeElement const& child0_child = child0.children[0]->second;
+    BOOST_REQUIRE_EQUAL("test::child0_child", child0_child.segment.getName());
+    BOOST_REQUIRE_EQUAL("test::j2", child0_child.segment.getJoint().getName());
+}
+
+BOOST_AUTO_TEST_CASE(it_ignores_links_not_attached_to_the_first_link)
+{
+    string sdf = "\
+        <sdf version=\"1.6\">\
+        <model name=\"test\">\
+            <link name=\"root\" />\
+            <link name=\"other_root\" />\
+            <link name=\"child\" />\
+            \
+            <joint name=\"j0\" type=\"fixed\">\
+                <parent>other_root</parent>\
+                <child>child</child>\
+            </joint>\
+        </model>\
+        </sdf>";
+    Tree tree;
+    BOOST_REQUIRE(treeFromString(sdf, tree, kdl_parser::ROBOT_MODEL_SDF));
+    BOOST_REQUIRE_EQUAL(1, tree.getNrOfSegments());
+    BOOST_REQUIRE_EQUAL("test::root", tree.getRootSegment()->second.children[0]->second.segment.getName());
+}
+
+BOOST_AUTO_TEST_CASE(it_does_add_links_not_attached_to_the_first_link_if_the_model_is_static)
+{
+    string sdf = "\
+        <sdf version=\"1.6\">\
+        <model name=\"test\">\
+            <link name=\"root\" />\
+            <link name=\"other_root\" />\
+            <link name=\"child\" />\
+            \
+            <joint name=\"j0\" type=\"fixed\">\
+                <parent>other_root</parent>\
+                <child>child</child>\
+            </joint>\
+            <static>true</static>\
+        </model>\
+        </sdf>";
+
+    Tree tree;
+    BOOST_REQUIRE(treeFromString(sdf, tree, kdl_parser::ROBOT_MODEL_SDF));
+    BOOST_REQUIRE_EQUAL(3, tree.getNrOfSegments());
+    BOOST_REQUIRE_EQUAL("test::root", tree.getRootSegment()->second.children[0]->second.segment.getName());
+    BOOST_REQUIRE_EQUAL("test::other_root", tree.getRootSegment()->second.children[1]->second.segment.getName());
+    BOOST_REQUIRE_EQUAL("test::child", tree.getRootSegment()->second.children[1]->second.children[0]->second.segment.getName());
+}
+

--- a/test/test_sdf.cpp
+++ b/test/test_sdf.cpp
@@ -106,3 +106,14 @@ BOOST_AUTO_TEST_CASE(it_does_add_links_not_attached_to_the_first_link_if_the_mod
     BOOST_REQUIRE_EQUAL("test::child", tree.getRootSegment()->second.children[1]->second.children[0]->second.segment.getName());
 }
 
+BOOST_AUTO_TEST_CASE(it_returns_an_empty_tree_for_a_model_without_links)
+{
+    string sdf = "\
+        <sdf version=\"1.6\">\
+        <model name=\"test\" />\
+        </sdf>";
+
+    Tree tree;
+    BOOST_REQUIRE(treeFromString(sdf, tree, kdl_parser::ROBOT_MODEL_SDF));
+    BOOST_REQUIRE_EQUAL(0, tree.getNrOfSegments());
+}


### PR DESCRIPTION
This PR adds a conversion from a SDF model to KDL. It extends the root interfaces (treeFromFile/treeFromString) to allow setting the format, and also allows to auto-detect the format from extension in the treeFromFile case. URDF remains the default in the PR.