### PR TITLE
add utilities to handle model file and strings in both URDF and SDF

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 rock_find_cmake(Boost REQUIRED COMPONENTS thread system)
 
-rock_library(kdl_parser SOURCES kdl_parser.cpp sdf.cpp
-                        HEADERS kdl_parser.hpp
+rock_library(kdl_parser SOURCES kdl_parser.cpp RobotModelFormat.cpp sdf.cpp
+                        HEADERS kdl_parser.hpp RobotModelFormat.hpp
                         DEPS_PKGCONFIG 
 			  eigen3 
 			  orocos-kdl 

--- a/src/RobotModelFormat.cpp
+++ b/src/RobotModelFormat.cpp
@@ -1,0 +1,31 @@
+#include <kdl_parser/RobotModelFormat.hpp>
+#include <stdexcept>
+#include <fstream>
+#include <base-logging/Logging.hpp>
+
+using namespace kdl_parser;
+using namespace std;
+
+const char* kdl_parser::formatNameFromID(int type)
+{
+    switch(type)
+    {
+        case ROBOT_MODEL_AUTO: return "autodetected";
+        case ROBOT_MODEL_URDF: return "URDF";
+        case ROBOT_MODEL_SDF: return "SDF";
+        default:
+            throw std::invalid_argument("invalid model type ID given");
+    }
+}
+
+ROBOT_MODEL_FORMAT kdl_parser::guessFormatFromFilename(const std::string& file)
+{
+    if (file.substr(file.size() - 4) == ".sdf")
+        return ROBOT_MODEL_SDF;
+    if (file.substr(file.size() - 5) == ".urdf")
+        return ROBOT_MODEL_URDF;
+    if (file.substr(file.size() - 6) == ".world")
+        return ROBOT_MODEL_SDF;
+    throw std::invalid_argument("cannot guess robot model format for " + file);
+}
+

--- a/src/RobotModelFormat.cpp
+++ b/src/RobotModelFormat.cpp
@@ -29,3 +29,32 @@ ROBOT_MODEL_FORMAT kdl_parser::guessFormatFromFilename(const std::string& file)
     throw std::invalid_argument("cannot guess robot model format for " + file);
 }
 
+pair<string, ROBOT_MODEL_FORMAT> kdl_parser::getRobotModelString(
+        string const& model, ROBOT_MODEL_FORMAT format)
+{
+    char const* sdf_header  = "<sdf";
+    char const* urdf_header = "<robot";
+    if(model.find(sdf_header) != string::npos)
+    {
+        if (format == ROBOT_MODEL_URDF)
+            throw std::invalid_argument("string contains the '<sdf' marker but the type was ROBOT_MODEL_SDF");
+        return make_pair(model, ROBOT_MODEL_SDF);
+    }
+    else if(model.find(urdf_header) != string::npos)
+    {
+        if (format == ROBOT_MODEL_SDF)
+            throw std::invalid_argument("string contains the '<urdf' marker but the type was ROBOT_MODEL_URDF");
+        return make_pair(model, ROBOT_MODEL_URDF);
+    }
+
+    if (format == ROBOT_MODEL_AUTO)
+        format = guessFormatFromFilename(model);
+
+    ifstream file(model.c_str());
+    if(!file)
+        throw std::invalid_argument("Robot model file " + model + " does not exist");
+    return std::make_pair(
+            string((istreambuf_iterator<char>(file)), istreambuf_iterator<char>()),
+            format);
+}
+

--- a/src/RobotModelFormat.hpp
+++ b/src/RobotModelFormat.hpp
@@ -25,4 +25,19 @@ ROBOT_MODEL_FORMAT guessFormatFromFilename(const std::string& file);
  */
 const char* formatNameFromID(int type);
 
+/** Resolve a string that is either a XML robot model or a path to a file into
+ * the full XML string and its format
+ *
+ * @param model either a path to a model file, or the full XML model.
+ *   In the latter case, it is expected to start with the XML preamble
+ *   (<?xml ...?>).
+ * @param format the model format. ROBOT_MODEL_AUTO can only be used in
+ *   the case of a path, the function does not know how to auto-detect
+ *   the format of a XML string yet.
+ * @return the XML string and its format
+ */
+std::pair<std::string, ROBOT_MODEL_FORMAT> getRobotModelString(
+        const std::string& model, ROBOT_MODEL_FORMAT format);
+}
+
 #endif

--- a/src/RobotModelFormat.hpp
+++ b/src/RobotModelFormat.hpp
@@ -1,0 +1,28 @@
+#ifndef KDL_PARSER_ROBOT_MODEL_FORMAT_HPP
+#define KDL_PARSER_ROBOT_MODEL_FORMAT_HPP
+
+#include <string>
+#include <utility>
+
+namespace kdl_parser{
+
+//define format of robot model
+enum ROBOT_MODEL_FORMAT
+{
+    //! try to guess the format
+    ROBOT_MODEL_AUTO,
+    //! URDF model
+    ROBOT_MODEL_URDF,
+    //! SDF model
+    ROBOT_MODEL_SDF
+};
+
+/** Returns the model format based on a filename's extension
+ */
+ROBOT_MODEL_FORMAT guessFormatFromFilename(const std::string& file);
+
+/** Returns the name of one of the ROBOT_MODEL_* format IDs
+ */
+const char* formatNameFromID(int type);
+
+#endif

--- a/src/kdl_parser.cpp
+++ b/src/kdl_parser.cpp
@@ -46,29 +46,6 @@ using namespace KDL;
 
 namespace kdl_parser{
 
-const char* formatNameFromID(int type)
-{
-    switch(type)
-    {
-        case ROBOT_MODEL_AUTO: return "autodetected";
-        case ROBOT_MODEL_URDF: return "URDF";
-        case ROBOT_MODEL_SDF: return "SDF";
-        default:
-            throw std::invalid_argument("invalid model type ID given");
-    }
-}
-
-ROBOT_MODEL_FORMAT guessFormatFromFilename(const std::string& file)
-{
-    if (file.substr(file.size() - 4) == ".sdf")
-        return ROBOT_MODEL_SDF;
-    if (file.substr(file.size() - 5) == ".urdf")
-        return ROBOT_MODEL_URDF;
-    if (file.substr(file.size() - 6) == ".world")
-        return ROBOT_MODEL_SDF;
-    throw std::invalid_argument("cannot guess robot model format for " + file);
-}
-
 /**
  * load kdl tree from sdf xml string
  */

--- a/src/kdl_parser.hpp
+++ b/src/kdl_parser.hpp
@@ -42,27 +42,9 @@
 #include <tinyxml.h>
 #include <sdf/sdf.hh>
 #include "urdf_model/model.h"
+#include <kdl_parser/RobotModelFormat.hpp>
 
 namespace kdl_parser{
-
-//define format of robot model
-enum ROBOT_MODEL_FORMAT
-{
-    //! try to guess the format
-    ROBOT_MODEL_AUTO,
-    //! URDF model
-    ROBOT_MODEL_URDF,
-    //! SDF model
-    ROBOT_MODEL_SDF
-};
-
-/** Returns the model format based on a filename's extension
- */
-ROBOT_MODEL_FORMAT guessFormatFromFilename(const std::string& file);
-
-/** Returns the name of one of the ROBOT_MODEL_* format IDs
- */
-const char* formatNameFromID(int type);
 
 /** Constructs a KDL tree from a file, given the file name
  * \param file The filename from where to read the xml

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,4 @@
+configure_file(TestConfig.hpp.in TestConfig.hpp @ONLY)
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 rock_testsuite(test_suite suite.cpp
-   test_sdf.cpp
-   DEPS kdl_parser)
+    test_sdf.cpp test_RobotModelFormat.cpp DEPS kdl_parser)

--- a/test/TestConfig.hpp.in
+++ b/test/TestConfig.hpp.in
@@ -1,0 +1,6 @@
+#ifndef KDL_PARSER_TEST_CONFIG_HPP
+#define KDL_PARSER_TEST_CONFIG_HPP
+
+#define TEST_DATA_PATH(x) "@CMAKE_CURRENT_SOURCE_DIR@/data/" x
+
+#endif

--- a/test/TestHelpers.hpp
+++ b/test/TestHelpers.hpp
@@ -1,0 +1,17 @@
+#ifndef KDL_PARSER_TEST_HELPERS_HPP
+#define KDL_PARSER_TEST_HELPERS_HPP
+
+#include "TestConfig.hpp"
+#include <fstream>
+#include <string>
+
+namespace {
+    inline std::string readFile(std::string const& path)
+    {
+        std::ifstream istream(path);
+        return std::string( (std::istreambuf_iterator<char>(istream) ),
+                            (std::istreambuf_iterator<char>()    ) );
+    }
+}
+
+#endif

--- a/test/data/getRobotModelString.anything
+++ b/test/data/getRobotModelString.anything
@@ -1,0 +1,1 @@
+Anything, really

--- a/test/data/getRobotModelString.sdf
+++ b/test/data/getRobotModelString.sdf
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<sdf version="1.5" />
+

--- a/test/data/getRobotModelString.urdf
+++ b/test/data/getRobotModelString.urdf
@@ -1,0 +1,2 @@
+<?xml version="1.0"?>
+<robot name="test" />

--- a/test/data/getRobotModelString.world
+++ b/test/data/getRobotModelString.world
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<sdf version="1.5" />
+

--- a/test/test_RobotModelFormat.cpp
+++ b/test/test_RobotModelFormat.cpp
@@ -1,0 +1,97 @@
+#include <boost/test/unit_test.hpp>
+#include <kdl_parser/kdl_parser.hpp>
+#include "TestHelpers.hpp"
+
+using namespace kdl_parser;
+using namespace std;
+using namespace KDL;
+
+static const string SDF_STRING = "\
+    <sdf version=\"1.6\">\
+    <model name=\"test\" \\>\
+    </sdf>";
+
+static const string URDF_STRING = "\
+    <robot name='urdf_robot'>\
+      <link name='link' />\
+    </robot>";
+
+static const string RANDOM_STRING = "string with some content";
+
+BOOST_AUTO_TEST_CASE(it_autodetects_a_sdf_xml_string_as_SDF)
+{
+    BOOST_REQUIRE(make_pair(SDF_STRING, ROBOT_MODEL_SDF) == getRobotModelString(SDF_STRING, ROBOT_MODEL_AUTO));
+}
+
+BOOST_AUTO_TEST_CASE(it_returns_a_sdf_xml_string_as_SDF_if_given_the_format_explicitely)
+{
+    BOOST_REQUIRE(make_pair(SDF_STRING, ROBOT_MODEL_SDF) == getRobotModelString(SDF_STRING, ROBOT_MODEL_SDF));
+}
+
+BOOST_AUTO_TEST_CASE(it_throws_if_given_something_that_looks_like_a_URDF_string_and_format_is_SDF)
+{
+    BOOST_REQUIRE_THROW(getRobotModelString(URDF_STRING, ROBOT_MODEL_SDF), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(it_autodetects_a_URDF_xml_string_as_URDF)
+{
+    BOOST_REQUIRE(make_pair(URDF_STRING, ROBOT_MODEL_URDF) == getRobotModelString(URDF_STRING, ROBOT_MODEL_AUTO));
+}
+
+BOOST_AUTO_TEST_CASE(it_returns_a_URDF_xml_string_as_URDF_if_given_the_format_explicitely)
+{
+    BOOST_REQUIRE(make_pair(URDF_STRING, ROBOT_MODEL_URDF) == getRobotModelString(URDF_STRING, ROBOT_MODEL_URDF));
+}
+
+BOOST_AUTO_TEST_CASE(it_throws_if_given_something_that_looks_like_a_SDF_string_and_format_is_URDF)
+{
+    BOOST_REQUIRE_THROW(getRobotModelString(SDF_STRING, ROBOT_MODEL_URDF), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(it_throws_if_the_file_does_not_exist)
+{
+    string path     = TEST_DATA_PATH("doesNotExist.urdf");
+    BOOST_REQUIRE_THROW(getRobotModelString(path, ROBOT_MODEL_AUTO), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(it_automatically_detects_a_URDF_file_from_the_urdf_extension)
+{
+    string path     = TEST_DATA_PATH("getRobotModelString.urdf");
+    string contents = readFile(path);
+    BOOST_REQUIRE(make_pair(contents, ROBOT_MODEL_URDF) == getRobotModelString(path, ROBOT_MODEL_AUTO));
+}
+
+BOOST_AUTO_TEST_CASE(it_automatically_detects_a_SDF_file_from_the_sdf_extension)
+{
+    string path     = TEST_DATA_PATH("getRobotModelString.sdf");
+    string contents = readFile(path);
+    BOOST_REQUIRE(make_pair(contents, ROBOT_MODEL_SDF) == getRobotModelString(path, ROBOT_MODEL_AUTO));
+}
+
+BOOST_AUTO_TEST_CASE(it_automatically_detects_a_SDF_file_from_the_world_extension)
+{
+    string path     = TEST_DATA_PATH("getRobotModelString.world");
+    string contents = readFile(path);
+    BOOST_REQUIRE(make_pair(contents, ROBOT_MODEL_SDF) == getRobotModelString(path, ROBOT_MODEL_AUTO));
+}
+
+BOOST_AUTO_TEST_CASE(it_throws_if_the_extension_is_not_known_and_the_format_is_auto)
+{
+    string path     = TEST_DATA_PATH("getRobotModelString.anything");
+    BOOST_REQUIRE_THROW(getRobotModelString(path, ROBOT_MODEL_AUTO), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(it_ignores_the_extension_if_explicitely_passed_URDF_as_model_format)
+{
+    string path     = TEST_DATA_PATH("getRobotModelString.anything");
+    string contents = readFile(path);
+    BOOST_REQUIRE(make_pair(contents, ROBOT_MODEL_URDF) == getRobotModelString(path, ROBOT_MODEL_URDF));
+}
+
+BOOST_AUTO_TEST_CASE(it_ignores_the_extension_if_explicitely_passed_SDF_as_model_format)
+{
+    string path     = TEST_DATA_PATH("getRobotModelString.anything");
+    string contents = readFile(path);
+    BOOST_REQUIRE(make_pair(contents, ROBOT_MODEL_SDF) == getRobotModelString(path, ROBOT_MODEL_SDF));
+}
+


### PR DESCRIPTION
This pull requests extracts the robot format enum and utilities, and provide a common entry
point to convert a string that points to a robot model (either as plain XML or as a file) into
a string 