### PR TITLE
sdf: fix pose of the canonical link

### DIFF
--- a/src/sdf.cpp
+++ b/src/sdf.cpp
@@ -153,7 +153,7 @@ static void convertSdfTree(
     string root_link_name = model_name + "::" + sdf_root_link->Get<string>("name");
     KDL::Segment segment(root_link_name,
             KDL::Joint(root_link_name, KDL::Joint::None),
-            getLinkPose(sdf_root_link),
+            KDL::Frame(KDL::Rotation::Identity(), KDL::Vector::Zero()),
             KDL::RigidBodyInertia());
     tree.addSegment(segment, model_name);
 


### PR DESCRIPTION
The "model pose" is the pose of the model's first link. Fix the
link between the KDL root ("model frame") and the first link ("first SDF link")