### PR TITLE
Sdformat9 12 compat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # CMakeLists.txt has to be located in the project folder and cmake has to be
 # executed from 'project/build' with 'cmake ../'.
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.1)
+project(kdl_parser VERSION 0.1)
 find_package(Rock)
-rock_init(kdl_parser 0.1)
+rock_init()
 rock_standard_layout()
-SET (CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/.orogen/config")

--- a/manifest.xml
+++ b/manifest.xml
@@ -11,5 +11,6 @@
   <depend package="base/types"/>
   <depend package="control/urdfdom"/>
   <depend package="control/sdformat"/>
+  <depend package="external/tinyxml"/>
 
 </package>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,19 @@
 rock_find_cmake(Boost REQUIRED COMPONENTS thread system)
 
+pkg_check_modules(SDFORMAT QUIET sdformat)
+pkg_check_modules(SDFORMAT9 QUIET sdformat9)
+pkg_check_modules(SDFORMAT12 QUIET sdformat12)
+
+if(${SDFORMAT_FOUND})
+  set(SDFORMAT_PKGCONFIG_NAME "sdformat")
+elseif(${SDFORMAT9_FOUND})
+  set(SDFORMAT_PKGCONFIG_NAME "sdformat9")
+elseif(${SDFORMAT12_FOUND})
+  set(SDFORMAT_PKGCONFIG_NAME "sdformat12")
+else()
+  message(SEND_ERROR "Could not find sdformat, sdformat9 or sdformat12 with pkg-config")
+endif()
+
 rock_library(kdl_parser SOURCES kdl_parser.cpp RobotModelFormat.cpp sdf.cpp
                         HEADERS kdl_parser.hpp RobotModelFormat.hpp
                         DEPS_PKGCONFIG 
@@ -9,5 +23,5 @@ rock_library(kdl_parser SOURCES kdl_parser.cpp RobotModelFormat.cpp sdf.cpp
 			  tinyxml
                           urdfdom_headers 
 			  urdfdom
-                          sdformat
+                          ${SDFORMAT_PKGCONFIG_NAME}
 )


### PR DESCRIPTION
sdformat started to change its pkg-config file name for each major version, so we need to check for the common variants. This also has a small update to the main CMakeLists.txt, adjusting the usage of rock_init, removing a CMAKE_MODULE_PATH that does not exist for a library package and adds a dependency to external/tinyxml that was missed because normally, the package stack using kdl_parser requires it.